### PR TITLE
Fix Invalid Parameter Type

### DIFF
--- a/src/kms.js
+++ b/src/kms.js
@@ -25,7 +25,7 @@ const getKms = module.exports._getKms = (config) => {
 // Wrapper for kms.encrypt
 module.exports.encrypt = (text, config) => {
   return new Promise((resolve, reject) => {
-    getKms(config).encrypt({ Plaintext: text }, (error, data) => {
+    getKms(config).encrypt({ Plaintext: String(text) }, (error, data) => {
       if (error) {
         reject(error)
       } else {


### PR DESCRIPTION
Fixes an Invalid Parameter Type error that occurs when the attribute value of an environment variable is entirely numbers.