### PR TITLE
README: Update serverless.yml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ which are then merged into a .env file on deployment.
 File example:
 
 ```yaml
-development: #stage
+dev: #stage
     foo: bar #cleartext variable
     bla: crypted:bc89hwnch8hncoaiwjnd... #encrypted variable
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ custom:
   envFiles: #YAML files used to create .env file
     - environment.yml
   envEncryptionKeyId: #KMS Key used for encrypting values
-    development: ${env:AWS_KMS_KEYID} #Key used for development-stage
+    dev: ${env:AWS_KMS_KEYID} #Key used for development-stage
 ```
 
 ### 4. Add the .env file to your .gitignore


### PR DESCRIPTION
The default development stage is `dev`. Using `development` returns error:

> Missing required key 'KeyId' in params