### PR TITLE
Local invoke support added again

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -50,6 +50,8 @@ class ServerlessEnvGeneratorPlugin {
       'before:deploy:createDeploymentArtifacts': this.writeDotEnvFile.bind(this),
       'after:deploy:createDeploymentArtifacts': this.removeDotEnvFile.bind(this),
       'before:offline:start:init': this.setEnvironment.bind(this),
+      'before:invoke:local:invoke': this.writeDotEnvFile.bind(this),
+      'after:invoke:local:invoke': this.removeDotEnvFile.bind(this),
       'local-dev-server:loadEnvVars': this.setEnvironment.bind(this)
     }
   }


### PR DESCRIPTION
In some reason local invoke support was removed.
It was added by https://github.com/DieProduktMacher/serverless-env-generator/pull/6 a few month ago.