### PR TITLE
add option to keep .env file after being generated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,13 @@ class ServerlessEnvGeneratorPlugin {
         commands: {
           generate: {
             usage: 'Creates the .env file manually',
-            lifecycleEvents: ['write']
+            lifecycleEvents: ['write'],
+            options: {
+              keepEnvFile: {
+                usage: 'Keep .env file after being manually generated',
+                shortcut: 'k'
+              }
+            }
           }
         }
       }
@@ -82,7 +88,7 @@ class ServerlessEnvGeneratorPlugin {
     this.serverless.cli.log('Creating .env file...')
     process
       .on('exit', () => {
-        if (fs.existsSync(config.dotEnvPath)) {
+        if (fs.existsSync(config.dotEnvPath && !this.options.keepEnvFile)) {
           fs.removeSync(config.dotEnvPath);
             this.serverless.cli.log('Removed .env file')
         }

--- a/test/index.js
+++ b/test/index.js
@@ -249,6 +249,25 @@ describe('index.js', () => {
     })
   })
 
+  it('should write and keep .env file upon manual generation', () => {
+    initEnvGenerator({
+      keepEnvFile: true
+    })
+    sandbox.stub(helper, 'getEnvVars').callsFake(() => {
+      return Promise.resolve(defaultEnvFiles)
+    })
+    sandbox.stub(fs, 'writeFile').callsFake((file, content) => {
+      return Promise.resolve()
+    })
+    sandbox.stub(fs, 'remove').callsFake(_ => {
+      return Promise.resolve()
+    })
+    return envGenerator.hooks['env:generate:write']().then(_ => {
+      expect(fs.writeFile.callCount).to.equal(1)
+      expect(fs.remove.callCount).to.equal(0)
+    })
+  })
+
   it('should work with single kms key', () => {
     serverless.service.custom.envEncryptionKeyId = 'allthesinglekeys'
     initEnvGenerator({})


### PR DESCRIPTION
Enable developers to keep .env file after being generated by `sls env generate` command. Might be useful if file is being used for testing or local development with running app server i.e. koa using serverless-http